### PR TITLE
chore: split Dockerfiles into separate node versions

### DIFF
--- a/Dockerfile.node10-nsis
+++ b/Dockerfile.node10-nsis
@@ -1,0 +1,40 @@
+FROM ubuntu:16.04
+
+MAINTAINER Jeff Dickey
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+    apt-utils \
+    bzip2 \
+    curl \
+    git \
+    ca-certificates \
+    ssh \
+    osslsigncode \
+    python-dev \
+    locales \
+    apt-transport-https \
+    nsis \
+    p7zip-full \
+    xz-utils \
+    gnupg \
+  && \
+  curl https://bootstrap.pypa.io/get-pip.py | python && \
+  pip install awscli --upgrade && \
+  aws configure set preview.cloudfront true && \
+  locale-gen && \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+  apt-get install -y --no-install-recommends nodejs yarn && \
+  apt-get clean && apt-get -y autoremove && \
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /root/.cache/* \
+    /var/cache/*
+
+CMD bash

--- a/Dockerfile.node11-nsis
+++ b/Dockerfile.node11-nsis
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 MAINTAINER Jeff Dickey
 

--- a/Dockerfile.node12-nsis
+++ b/Dockerfile.node12-nsis
@@ -1,0 +1,40 @@
+FROM ubuntu:16.04
+
+MAINTAINER Jeff Dickey
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+    apt-utils \
+    bzip2 \
+    curl \
+    git \
+    ca-certificates \
+    ssh \
+    osslsigncode \
+    python-dev \
+    locales \
+    apt-transport-https \
+    nsis \
+    p7zip-full \
+    xz-utils \
+    gnupg \
+  && \
+  curl https://bootstrap.pypa.io/get-pip.py | python && \
+  pip install awscli --upgrade && \
+  aws configure set preview.cloudfront true && \
+  locale-gen && \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+  apt-get install -y --no-install-recommends nodejs yarn && \
+  apt-get clean && apt-get -y autoremove && \
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /root/.cache/* \
+    /var/cache/*
+
+CMD bash


### PR DESCRIPTION
This PR splits our `nsis` Dockerfiles into several Dockerfiles suffixed with the node version they are built for. In order to try and keep things up to date this repo should reflect the current supported Dockerfiles for the images we're using in CI. Changes to any Dockerfiles should be pushed back up here before pushing new images to docker hub.

This pr also changes the base image to use `ubuntu:16.04`.
`ubuntu:18.04` doesn't appear to work in the CI for testing against [`oclif/dev-cli`](https://github.com/oclif/dev-cli).